### PR TITLE
added parameter nscatimeout to allow for connections with more latency

### DIFF
--- a/lib/send_nsca/send_nsca.rb
+++ b/lib/send_nsca/send_nsca.rb
@@ -10,6 +10,7 @@ module SendNsca
     
     # todo: replace timeout with a better method of handling communication timeouts.
     require 'timeout'
+    attr_accessor :nscatimeout
     
     # params for connecting to the nsca/nagios server
     attr_accessor  :nscahost
@@ -56,12 +57,13 @@ module SendNsca
       @status = args[:status]
       @connected = false
       @password = args[:password] || ''
+      @timeout = args[:nscatimeout] || 1
 
     end
 
     def connect_and_get_keys
       begin
-        timeout(1) do #the server has one second to answer
+        timeout(@timeout) do #the server has one second to answer
           @tcp_client = TCPSocket.open(@nscahost, @port)
           @connected = true
           @xor_key_and_timestamp = @tcp_client.recv(132)


### PR DESCRIPTION
Hello,

when using this gem and the nsca listener is not on the same machine but in fact on another site, one second of latency sometimes isn't enough. I've added the parameter nscatimeout (which defaults to the initial value of 1 if not specified) to allow for more latency.

This is my first pull request so I'm glad for any advice, formally and otherwise.

-Armin